### PR TITLE
Allow ansible-lint/flake8 to pass

### DIFF
--- a/iptables_raw.py
+++ b/iptables_raw.py
@@ -347,7 +347,7 @@ class Iptables:
     def _is_alpine(self):
         return os.path.isfile('/etc/alpine-release')
 
-    # If /etc/arch-release exist, this means this is an ArchLinux OS 
+    # If /etc/arch-release exist, this means this is an ArchLinux OS
     def _is_arch_linux(self):
         return os.path.isfile('/etc/arch-release')
 


### PR DESCRIPTION
Removing space from end of line for ansible-lint/flake8

OME are manually patching this file on their own fork at https://github.com/openmicroscopy/ansible-role-iptables-raw/blob/master/README.md